### PR TITLE
Integrate PR2 with name editing and KDZ format updates

### DIFF
--- a/kdv/kdv.kv
+++ b/kdv/kdv.kv
@@ -9,6 +9,40 @@
 <LabelJ@Label>:
     font_name: './img/ipag.ttf'
 
+<InlineEditableName>:
+    Label:
+        id: display
+        text: root.display_text
+        font_name: './img/ipag.ttf'
+        color: 1, 1, 1, 1
+        outline_width: dp(1)
+        outline_color: 0, 0, 0, 1
+        halign: 'center' if root.kind == 'team' else 'left'
+        valign: 'middle'
+        text_size: self.size
+        pos: root.pos
+        size: root.size
+    TextInput:
+        id: editor
+        text: root.display_text
+        font_name: './img/ipag.ttf'
+        background_normal: ''
+        background_active: ''
+        background_color: 0, 0, 0, 0
+        foreground_color: 0, 0, 0, 0
+        cursor_color: 1, 1, 1, 1
+        multiline: False
+        write_tab: False
+        opacity: 1 if self.focus else 0
+        halign: 'center' if root.kind == 'team' else 'left'
+        valign: 'middle'
+        padding: dp(0), dp(2)
+        on_focus: root.on_editor_focus(self, self.focus)
+        on_text: root.on_editor_text(self, self.text)
+        on_text_validate: root.on_editor_text_validate(self)
+        pos: root.pos
+        size: root.size
+
 <NameLabel@LabelJ>:
     pos: (self.parent.x - self.width + dp(10), self.parent.y - self.height) if self.parent else (0, 0)
     font_size: sp(20)
@@ -36,22 +70,20 @@
             pos: self.pos
             size: self.size
     BoxLayout:
-        LabelJ:
-            text: root.team_name[:10]
-            text_size: self.size
-            halign: 'center'
-            outline_width: dp(1)
+        InlineEditableName:
+            id: name_field
+            item_index: root.team_index
+            kind: "team"
+            display_text: root.team_name
+            size_hint_x: .78
             font_size: sp(20)
-            canvas.before:
-                Color:
-                    rgba:0,0,0, 1
         Label:
             text: str(root.score)
             text_size: self.size
             halign: 'center'
             outline_width: dp(1)
             font_size: sp(20)
-            size_hint_x: .4
+            size_hint_x: .25
 
     Label:
         text: ""
@@ -260,16 +292,15 @@
             text_size: self.size
             halign: 'right'
             valign: 'middle'
-        LabelJ:
-            text: " {}".format(root.name)
+        InlineEditableName:
+            id: name_field
+            item_index: root.player_index
+            kind: "player"
+            display_text: root.name
             size_hint_y: None
-            text_size: self.width, None
-            height: self.texture_size[1]
+            height: dp(28)
             font_size: sp(15)
-            outline_width: dp(1)
-            size_hint_x: .5
-            halign: 'left'
-            valign: 'middle'
+            size_hint_x: .68
 
         Label:
             # Main Weapon
@@ -338,34 +369,28 @@
                 size: self.size
         BoxLayout:
             size_hint_y: None
-            height: dp(20)
-            LabelJ:
-                text: root.team_name[:10]
-                text_size: self.size
-                size: self.texture_size
-                halign: 'center'
-                outline_width: dp(1)
+            height: dp(28)
+            InlineEditableName:
+                id: name_field
+                item_index: root.team_index
+                kind: "team"
+                display_text: root.team_name
+                size_hint_x: .72
                 font_size: sp(18)
-                canvas.before:
-                    Color:
-                        rgba:0,0,0, 1
-                    #Line:
-                    #    points: self.right, self.y, self.right, self.top
-                    #    width: 1.5
             Label:
                 text: str(root.score)
                 text_size: self.size
                 halign: 'center'
                 outline_width: dp(1)
                 font_size: sp(20)
-                size_hint_x: .2
+                size_hint_x: .14
             Label:
                 text: "{}".format("Win" if root.is_winner else "")
                 text_size: self.size
                 halign: 'center'
                 outline_width: dp(1)
                 font_size: sp(20)
-                size_hint_x: .3
+                size_hint_x: .14
         BoxLayout:
             size_hint_y: None
             height: dp(30)
@@ -413,10 +438,12 @@
             font_size: sp(12)
     TeamPanel:
         id: team0
+        team_index: 0
         size_hint_y: .45
 
     TeamPanel:
         id: team1
+        team_index: 1
         size_hint_y: .45
 
 <NadeInfoPanel>:
@@ -605,10 +632,12 @@
                     spacing: dp(5)
                     ResultPanel:
                         id: result0
+                        team_index: 0
                         size_hint_y: None
                         height: dp(50)
                     ResultPanel:
                         id: result1
+                        team_index: 1
                         size_hint_y: None
                         height: dp(50)
                     Label:

--- a/kdv/kdv_app/app_controller.py
+++ b/kdv/kdv_app/app_controller.py
@@ -118,9 +118,8 @@ class KdvController:
             self.play()
 
     def increment_index(self, *args):
-        if self.root.current_ss_index >= self.root.ss_index_max:
+        if self.root.current_ss_index >= self.root.ss_index_max - 1:
             self.stop()
-            self.root.playing_event.cancel()
         else:
             self.root.current_ss_index += 1
 

--- a/kdv/kdv_app/constants.py
+++ b/kdv/kdv_app/constants.py
@@ -2,7 +2,6 @@ from kivy.utils import get_hex_from_color
 from .config_loader import default_json_config, load_config
 
 KDV_VER = "1.0.3"
-KDZ_FORMAT_VERSION = 1
 
 PLY_SIZE = 77
 TIMER_SIZE = 100

--- a/kdv/kdv_app/kdm.py
+++ b/kdv/kdv_app/kdm.py
@@ -1,6 +1,7 @@
-import zipfile
+import json
 import os
 import tempfile
+import zipfile
 import msgpack
 from dateutil.relativedelta import relativedelta
 
@@ -77,6 +78,7 @@ OVERLAY_SCALE_MAP = {
 IS_RAW = False
 
 class KdmObj:
+    NAME_OVERRIDES_ENTRY = "kdm_name_overrides.json"
 
     def __init__(self, path):
         
@@ -94,6 +96,8 @@ class KdmObj:
         kdm_byte = self.zf.read('kdm_matchstats')
         self.MatchStats = msgpack.unpackb(kdm_byte, use_list=False, raw=IS_RAW, unicode_errors='replace')
         self.RoundInfoList = self.MatchStats['RoundInfoList']
+        self.name_overrides = {"teams": {}, "players": {}}
+        self.load_name_overrides()
         self.rs = None
         
         # count the number of rounds for one-round mode
@@ -124,6 +128,47 @@ class KdmObj:
                 if index_text.isdigit():
                     self.round_traj_entries[int(index_text)] = filename
                 return
+
+    def load_name_overrides(self):
+        self.name_overrides = {"teams": {}, "players": {}}
+        try:
+            data = json.loads(self.zf.read(self.NAME_OVERRIDES_ENTRY).decode("utf-8"))
+        except (KeyError, OSError, UnicodeDecodeError, json.JSONDecodeError):
+            return
+        if not isinstance(data, dict):
+            return
+        teams = data.get("teams", {})
+        players = data.get("players", {})
+        self.name_overrides["teams"] = teams if isinstance(teams, dict) else {}
+        self.name_overrides["players"] = players if isinstance(players, dict) else {}
+
+    def save_name_overrides(self):
+        tmp_path = None
+        try:
+            fd, tmp_path = tempfile.mkstemp(prefix="kdv_", suffix=".kdz", dir=self.file_dir or ".")
+            os.close(fd)
+            with zipfile.ZipFile(tmp_path, "w") as zout:
+                for item in self.zf.infolist():
+                    if item.filename == self.NAME_OVERRIDES_ENTRY:
+                        continue
+                    zout.writestr(item, self.zf.read(item.filename))
+                zout.writestr(
+                    self.NAME_OVERRIDES_ENTRY,
+                    json.dumps(self.name_overrides, ensure_ascii=False, indent=2).encode("utf-8"),
+                )
+            self.zf.close()
+            os.replace(tmp_path, self.path)
+            self.zf = zipfile.ZipFile(self.path)
+            return True
+        except (OSError, zipfile.BadZipFile):
+            if tmp_path and os.path.exists(tmp_path):
+                try:
+                    os.remove(tmp_path)
+                except OSError:
+                    pass
+            if getattr(self.zf, "fp", None) is None:
+                self.zf = zipfile.ZipFile(self.path)
+            return False
 
     def get_round_trajectory_path(self, index):
         return self._get_round_trajectory_path(index, prefer_thumb=True)
@@ -179,6 +224,8 @@ class KdmObj:
             if item.filename == 'kdm_header':
                 zout.writestr(item, buffer)
             elif item.filename == 'kdm_matchstats':
+                zout.writestr(item, buffer)
+            elif item.filename == self.NAME_OVERRIDES_ENTRY:
                 zout.writestr(item, buffer)
             elif item.filename[:10] == 'kdm_round_' and int(item.filename[10:]) == index:
                 zout.writestr(item, buffer)

--- a/kdv/kdv_app/kdm.py
+++ b/kdv/kdv_app/kdm.py
@@ -149,6 +149,40 @@ class KdmObj:
         self.name_overrides["teams"] = teams if isinstance(teams, dict) else {}
         self.name_overrides["players"] = players if isinstance(players, dict) else {}
 
+    @classmethod
+    def read_name_overrides_entry(cls, path):
+        try:
+            with zipfile.ZipFile(path) as zf:
+                return zf.read(cls.NAME_OVERRIDES_ENTRY)
+        except (KeyError, OSError, zipfile.BadZipFile):
+            return None
+
+    @classmethod
+    def write_name_overrides_entry(cls, path, override_bytes):
+        if not override_bytes:
+            return True
+
+        file_dir = os.path.dirname(path)
+        tmp_path = None
+        try:
+            fd, tmp_path = tempfile.mkstemp(prefix="kdv_", suffix=".kdz", dir=file_dir or ".")
+            os.close(fd)
+            with zipfile.ZipFile(path) as zin, zipfile.ZipFile(tmp_path, "w") as zout:
+                for item in zin.infolist():
+                    if item.filename == cls.NAME_OVERRIDES_ENTRY:
+                        continue
+                    zout.writestr(item, zin.read(item.filename))
+                zout.writestr(cls.NAME_OVERRIDES_ENTRY, override_bytes)
+            os.replace(tmp_path, path)
+            return True
+        except (OSError, zipfile.BadZipFile):
+            if tmp_path and os.path.exists(tmp_path):
+                try:
+                    os.remove(tmp_path)
+                except OSError:
+                    pass
+            return False
+
     def save_name_overrides(self):
         tmp_path = None
         try:

--- a/kdv/kdv_app/kdv.py
+++ b/kdv/kdv_app/kdv.py
@@ -122,6 +122,50 @@ class Kdv(Widget):
         self.map_ui_service = MapUiService(self)
         self.round_list_presenter = RoundListPresenter(self)
 
+    def apply_name_overrides_to_matchstats(self):
+        if self.ko is None:
+            return
+        team_overrides = self.ko.name_overrides.get("teams", {})
+        if not isinstance(team_overrides, dict):
+            return
+
+        team_names = self.get_team_names()
+        if team_names is None:
+            return
+
+        for key, value in team_overrides.items():
+            try:
+                index = int(key)
+            except (TypeError, ValueError):
+                continue
+            if index not in (0, 1):
+                continue
+            team_names[index] = self.normalize_team_name(index, value)
+
+    def apply_name_overrides_to_round(self):
+        if self.ko is None or self.ko.rs is None:
+            return
+        player_overrides = self.ko.name_overrides.get("players", {})
+        if not isinstance(player_overrides, dict):
+            return
+
+        player_names = self.get_round_player_names()
+        if player_names is None:
+            return
+
+        for key, value in player_overrides.items():
+            try:
+                index = int(key)
+            except (TypeError, ValueError):
+                continue
+            if index < 0:
+                continue
+            while len(player_names) <= index:
+                player_names.append("")
+            normalized_name = str(value).strip() if value is not None else ""
+            if normalized_name:
+                player_names[index] = normalized_name
+
     def _keyboard_start(self):
         self._keyboard = Window.request_keyboard(self._keyboard_closed, self)
         self._keyboard.bind(on_key_down=self._on_keyboard_down)
@@ -241,6 +285,117 @@ class Kdv(Widget):
         ssrate = self.ko.Header["SnapshotRate"]
         time_list, tk_list, ctk_list, plant, plant_site, n_list = build_seekbar_hints(self.ko.rs, self.ss_index_max, ssrate)
         self.seekbar.draw_hints_w(time_list, tk_list, ctk_list, plant, plant_site, n_list)
+
+    def normalize_team_name(self, team_index, team_name):
+        normalized_name = str(team_name).strip() if team_name is not None else ""
+        if normalized_name == "":
+            normalized_name = "Team{}".format(team_index)
+        return normalized_name
+
+    def get_team_names(self):
+        if self.ko is None:
+            return None
+        team_names = self.ko.MatchStats.get("TeamName")
+        if team_names is None:
+            team_names = ["", ""]
+        elif not isinstance(team_names, list):
+            team_names = list(team_names)
+        self.ko.MatchStats["TeamName"] = team_names
+        while len(team_names) < 2:
+            team_names.append("")
+        return team_names
+
+    def get_round_player_names(self):
+        if self.ko is None or self.ko.rs is None:
+            return None
+        player_names = self.ko.rs.get("PlayerNames", [])
+        if not isinstance(player_names, list):
+            player_names = list(player_names)
+            self.ko.rs["PlayerNames"] = player_names
+        self.ko.rs_pname = player_names
+        return player_names
+
+    def sync_round_player_references(self, old_name, new_name):
+        if self.ko is None or self.ko.rs is None or old_name == new_name:
+            return
+
+        nades = self.ko.rs.get("NadesDrawingInfoMap") or []
+        for nade in nades:
+            if nade.get("ThrowerName") == old_name:
+                nade["ThrowerName"] = new_name
+
+        quoted_old_name = '"{}"'.format(old_name)
+        quoted_new_name = '"{}"'.format(new_name)
+        event_logs = self.ko.rs.get("EventLogs") or []
+        for event_log in event_logs:
+            log_text = event_log.get("Log")
+            if isinstance(log_text, str) and quoted_old_name in log_text:
+                event_log["Log"] = log_text.replace(quoted_old_name, quoted_new_name)
+
+    def sync_team_names(self):
+        team_names = self.get_team_names()
+        if team_names is None:
+            return
+
+        team0_name = self.normalize_team_name(0, team_names[0])
+        team1_name = self.normalize_team_name(1, team_names[1])
+        team_names[0] = team0_name
+        team_names[1] = team1_name
+
+        self.team0_name = team0_name
+        self.team1_name = team1_name
+
+        if "result0" in self.ids and "result1" in self.ids:
+            self.ids["result0"].team_name = team0_name
+            self.ids["result1"].team_name = team1_name
+
+        if self.teams_panel:
+            self.teams_panel.set_team_name(0, team0_name)
+            self.teams_panel.set_team_name(1, team1_name)
+
+    def rename_team(self, team_index, new_name):
+        if self.ko is None or team_index not in (0, 1):
+            return
+
+        team_names = self.get_team_names()
+        if team_names is None:
+            return
+        team_names[team_index] = new_name
+        self.ko.name_overrides.setdefault("teams", {})[str(team_index)] = self.normalize_team_name(team_index, new_name)
+        self.ko.save_name_overrides()
+
+        self.sync_team_names()
+        self.refresh()
+
+    def rename_player(self, player_index, new_name):
+        if self.ko is None or self.ko.rs is None or player_index < 0:
+            return
+
+        normalized_name = str(new_name).strip()
+        if normalized_name == "":
+            return
+
+        player_names = self.get_round_player_names()
+        if player_names is None:
+            return
+        while len(player_names) <= player_index:
+            player_names.append("")
+        old_name = str(player_names[player_index]) if player_index < len(player_names) else ""
+        player_names[player_index] = normalized_name
+
+        self.ko.name_overrides.setdefault("players", {})[str(player_index)] = normalized_name
+        self.ko.save_name_overrides()
+        self.sync_round_player_references(old_name, normalized_name)
+
+        if self.teams_panel and player_index < len(self.teams_panel.player_list):
+            self.teams_panel.player_list[player_index].name = normalized_name
+        if self.kdvmap and player_index < len(self.kdvmap.player_list):
+            self.kdvmap.player_list[player_index].namelabel.text = normalized_name
+        if self.nade_list_panel and hasattr(self.nade_list_panel, "refresh_from_data"):
+            self.nade_list_panel.refresh_from_data()
+        if self.event_logger:
+            self.event_logger.load_logs(self.ko.rs.get("EventLogs"))
+            self.event_logger.update(self.current_ss_index)
 
 
 class KdvApp(App):

--- a/kdv/kdv_app/kdv.py
+++ b/kdv/kdv_app/kdv.py
@@ -65,7 +65,7 @@ constants.apply_config(load_config())
 
 
 class Kdv(Widget):
-    ver = StringProperty("version")
+    ver = StringProperty("")
     team0_name = StringProperty("team0")
     team1_name = StringProperty("team1")
 

--- a/kdv/kdv_app/kdv.py
+++ b/kdv/kdv_app/kdv.py
@@ -34,6 +34,7 @@ from . import constants
 from .app_controller import KdvController
 from .config_loader import load_config
 from .constants import KDV_VER, KDZ_FORMAT_VERSION
+from .kdm import KdmObj
 from .loader import KdvLoader
 from .map_ui_service import MapUiService
 from .map_view import GrenadeLayer, KdvMap, MapBoard, Paint, Player
@@ -435,10 +436,16 @@ class KdvApp(App):
             if os.path.isfile(kdz):
                 matchstats = self.root.load_kdm_ver(kdz)
                 if matchstats.get("KdzFormatVersion") != KDZ_FORMAT_VERSION:
+                    name_overrides_entry = KdmObj.read_name_overrides_entry(kdz)
+                    if name_overrides_entry is not None:
+                        print("kdm_name_overrides.json was detected and preserved")
                     self.title = "KumaDemoViewer_" + KDV_VER + " is Parsing " + file_path_uni
                     res = self.make_kdz(file_path_uni)
                     print("res.returncode =", res.returncode)
                     if res.returncode == 0:
+                        if name_overrides_entry is not None:
+                            if not KdmObj.write_name_overrides_entry(kdz, name_overrides_entry):
+                                print("failed to preserve kdm_name_overrides.json")
                         filename = os.path.basename(file_path_uni)
                         self.title = "KumaDemoViewer_" + KDV_VER + "   " + filename
                         self.root.load_kdm(kdz)

--- a/kdv/kdv_app/kdv.py
+++ b/kdv/kdv_app/kdv.py
@@ -33,7 +33,7 @@ from kivy.uix.widget import Widget
 from . import constants
 from .app_controller import KdvController
 from .config_loader import load_config
-from .constants import KDV_VER, KDZ_FORMAT_VERSION
+from .constants import KDV_VER
 from .kdm import KdmObj
 from .loader import KdvLoader
 from .map_ui_service import MapUiService
@@ -405,9 +405,14 @@ class Kdv(Widget):
 
 
 class KdvApp(App):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.kdz_format_version = None
+
     def build(self):
         if hasattr(sys, "_MEIPASS"):
             resource_add_path(sys._MEIPASS)
+        self.kdz_format_version = self.load_parser_kdz_format_version()
         Builder.load_file(KV_PATH)
         Window.bind(on_dropfile=self.on_file_drop)
         self.title = "KumaDemoViewer_" + KDV_VER
@@ -424,6 +429,22 @@ class KdvApp(App):
             base_path = BASE_DIR
         return os.path.join(base_path, relative_path)
 
+    def load_parser_kdz_format_version(self):
+        try:
+            res = subprocess.run(
+                (self.resource_path("./kdv_parser.exe"), "-v"),
+                capture_output=True,
+                text=True,
+            )
+            if res.returncode == 0:
+                return int(res.stdout.strip())
+            print("failed to load kdz format version from kdv_parser.exe", file=sys.stderr)
+            print(res.stderr, file=sys.stderr)
+        except (OSError, ValueError) as e:
+            print("failed to load kdz format version from kdv_parser.exe", file=sys.stderr)
+            print(e, file=sys.stderr)
+        raise SystemExit(1)
+
     def on_file_drop(self, widget, file_path):
         file_path_uni = os.fsdecode(file_path)
 
@@ -435,7 +456,7 @@ class KdvApp(App):
         if ext == ".dem":
             if os.path.isfile(kdz):
                 matchstats = self.root.load_kdm_ver(kdz)
-                if matchstats.get("KdzFormatVersion") != KDZ_FORMAT_VERSION:
+                if self.kdz_format_version != matchstats.get("KdzFormatVersion"):
                     name_overrides_entry = KdmObj.read_name_overrides_entry(kdz)
                     if name_overrides_entry is not None:
                         print("kdm_name_overrides.json was detected and preserved")
@@ -472,7 +493,7 @@ class KdvApp(App):
             return
         elif ext == ".kdz":
             matchstats = self.root.load_kdm_ver(file_path_uni)
-            if matchstats.get("KdzFormatVersion") != KDZ_FORMAT_VERSION:
+            if self.kdz_format_version != matchstats.get("KdzFormatVersion"):
                 print("KDZ format version mismatch. Please reparse from the original .dem file.")
                 self.title = "KumaDemoViewer_" + KDV_VER
                 return

--- a/kdv/kdv_app/loader.py
+++ b/kdv/kdv_app/loader.py
@@ -32,12 +32,6 @@ class KdvLoader:
         root.demo_tick = int(root.ko.Header["TickRate"])
         root.round_index_max = len(root.ko.MatchStats["RoundInfoList"])
 
-        root.team0_name = root.ids["result0"].team_name = root.ko.MatchStats["TeamName"][0]
-        root.team1_name = root.ids["result1"].team_name = root.ko.MatchStats["TeamName"][1]
-        if root.team0_name == "":
-            root.team0_name = root.ids["result0"].team_name = "Team0"
-        if root.team1_name == "":
-            root.team1_name = root.ids["result1"].team_name = "Team1"
         root.ids["result0"].score = root.ko.MatchStats["RoundInfoList"][-1]["CorrectScore"][0]
         root.ids["result1"].score = root.ko.MatchStats["RoundInfoList"][-1]["CorrectScore"][1]
 
@@ -53,7 +47,9 @@ class KdvLoader:
             )
         root.round_list_panel.data = round_data
 
+        root.apply_name_overrides_to_matchstats()
         root.teams_panel.load_teamnames(root.ko.MatchStats)
+        root.sync_team_names()
 
         root.map_name = root.ko.Header["MapName"]
         print(root.ko.Header["MapName"])
@@ -96,6 +92,7 @@ class KdvLoader:
 
         try:
             root.ko.load_roundsnapshots(root.current_round_index)
+            root.apply_name_overrides_to_round()
         except KeyError:
             print("RoundSnapshots KeyError")
             root.kdvmap.canvas.clear()

--- a/kdv/kdv_app/loader.py
+++ b/kdv/kdv_app/loader.py
@@ -11,7 +11,7 @@ class KdvLoader:
 
     def load_kdm_ver(self, file_path):
         matchstats = kdm.read_matchstats(file_path)
-        self.root.ver = "KDZ_Format = " + str(matchstats["KdzFormatVersion"])
+        self.root.ver = "KDZ_Format = " + str(matchstats.get("KdzFormatVersion", "unknown"))
         return matchstats
 
     def load_kdm(self, file_path):
@@ -28,7 +28,7 @@ class KdvLoader:
             print("Kdm is None.")
             return
 
-        root.ver = "KDZ_Format = " + str(root.ko.MatchStats["KdzFormatVersion"])
+        root.ver = "KDZ_Format = " + str(root.ko.MatchStats.get("KdzFormatVersion", "unknown"))
         root.second_per_frame = 1 / root.ko.Header["SnapshotRate"]
         root.demo_tick = int(root.ko.Header["TickRate"])
         root.round_index_max = len(root.ko.MatchStats["RoundInfoList"])

--- a/kdv/kdv_app/loader.py
+++ b/kdv/kdv_app/loader.py
@@ -11,7 +11,7 @@ class KdvLoader:
 
     def load_kdm_ver(self, file_path):
         matchstats = kdm.read_matchstats(file_path)
-        self.root.ver = "KDZ_VER_" + matchstats["KdmVersion"]
+        self.root.ver = "KDZ_Format = " + str(matchstats["KdzFormatVersion"])
         return matchstats
 
     def load_kdm(self, file_path):
@@ -28,7 +28,7 @@ class KdvLoader:
             print("Kdm is None.")
             return
 
-        root.ver = "KDZ_VER_" + root.ko.MatchStats["KdmVersion"]
+        root.ver = "KDZ_Format = " + str(root.ko.MatchStats["KdzFormatVersion"])
         root.second_per_frame = 1 / root.ko.Header["SnapshotRate"]
         root.demo_tick = int(root.ko.Header["TickRate"])
         root.round_index_max = len(root.ko.MatchStats["RoundInfoList"])

--- a/kdv/kdv_app/loader.py
+++ b/kdv/kdv_app/loader.py
@@ -11,7 +11,7 @@ class KdvLoader:
 
     def load_kdm_ver(self, file_path):
         matchstats = kdm.read_matchstats(file_path)
-        self.root.ver = "KDZ_Format = " + str(matchstats.get("KdzFormatVersion", "unknown"))
+        self.root.ver = "KDZ Version: " + str(matchstats.get("KdzFormatVersion", "unknown"))
         return matchstats
 
     def load_kdm(self, file_path):
@@ -28,7 +28,7 @@ class KdvLoader:
             print("Kdm is None.")
             return
 
-        root.ver = "KDZ_Format = " + str(root.ko.MatchStats.get("KdzFormatVersion", "unknown"))
+        root.ver = "KDZ Version: " + str(root.ko.MatchStats.get("KdzFormatVersion", "unknown"))
         root.second_per_frame = 1 / root.ko.Header["SnapshotRate"]
         root.demo_tick = int(root.ko.Header["TickRate"])
         root.round_index_max = len(root.ko.MatchStats["RoundInfoList"])

--- a/kdv/kdv_app/map_ui_service.py
+++ b/kdv/kdv_app/map_ui_service.py
@@ -41,7 +41,7 @@ class MapUiService:
                 root.mb_init_size = size
         else:
             min_scale = min(size[0] / root.mb_init_size[0], size[1] / root.mb_init_size[1])
-            root.kdvmap.scale = KDV_SCALE_MAP[root.map_name] * min_scale
+            root.kdvmap.scale = KDV_SCALE_MAP.get(root.map_name, 1.0) * min_scale
         root.refresh()
 
     def change_paint_color(self):

--- a/kdv/kdv_app/ui_components.py
+++ b/kdv/kdv_app/ui_components.py
@@ -10,12 +10,12 @@ from kivy.properties import (
     ObjectProperty,
     StringProperty,
 )
-from kivy.uix.behaviors import ButtonBehavior
 from kivy.uix.behaviors.togglebutton import ToggleButtonBehavior
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.button import Button
 from kivy.uix.gridlayout import GridLayout
 from kivy.uix.label import Label
+from kivy.uix.floatlayout import FloatLayout
 from kivy.uix.slider import Slider
 from kivy.uix.stacklayout import StackLayout
 from kivy.uix.togglebutton import ToggleButton
@@ -41,6 +41,7 @@ class SimpleRoundButton(ToggleButton):
 
 
 class ResultPanel(BoxLayout):
+    team_index = NumericProperty(0)
     team_name = StringProperty("-")
     score = NumericProperty(0)
 
@@ -58,6 +59,70 @@ class RoundTeamStat(BoxLayout):
 
     def __init__(self, **kwargs):
         super(RoundTeamStat, self).__init__(**kwargs)
+
+
+class InlineEditableName(FloatLayout):
+    item_index = NumericProperty(-1)
+    kind = StringProperty("team")
+    display_text = StringProperty("")
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._last_saved_value = ""
+        self.bind(display_text=self._sync_editor_text)
+
+    def _sync_editor_text(self, *_args):
+        editor = self.ids.get("editor")
+        display = self.ids.get("display")
+        if display is not None:
+            display.text = self.display_text
+        if editor is not None and not editor.focus:
+            self._last_saved_value = self.display_text
+            if editor.text != self.display_text:
+                editor.text = self.display_text
+
+    def on_editor_focus(self, editor, value):
+        if value:
+            editor.select_all()
+            return
+        self.commit_value()
+
+    def on_editor_text_validate(self, editor):
+        self.commit_value()
+        editor.focus = False
+
+    def on_editor_text(self, editor, value):
+        self.display_text = value
+
+    def commit_value(self):
+        app = App.get_running_app()
+        if not app or not app.root:
+            return
+
+        value = str(self.ids["editor"].text).strip() if "editor" in self.ids else ""
+        if self.kind == "team":
+            if self.item_index not in (0, 1):
+                return
+            if value == "":
+                value = "Team{}".format(self.item_index)
+            if value == self._last_saved_value:
+                self.display_text = value
+                return
+            app.root.rename_team(int(self.item_index), value)
+        else:
+            if self.item_index < 0:
+                return
+            if value == "":
+                self.ids["editor"].text = self._last_saved_value
+                self.display_text = self._last_saved_value
+                return
+            if value == self._last_saved_value:
+                self.display_text = value
+                return
+            app.root.rename_player(int(self.item_index), value)
+
+        self._last_saved_value = value
+        self.display_text = value
 
 
 class RoundPanel(ToggleButtonBehavior, BoxLayout):
@@ -190,6 +255,7 @@ class NadeLabel(Label):
 
 
 class PlayerPanel(BoxLayout):
+    player_index = NumericProperty(-1)
     slot = NumericProperty(0)
     name = StringProperty("-")
     color = ListProperty([0, 0, 0, 0])
@@ -283,6 +349,7 @@ class PlayerPanel(BoxLayout):
 
 
 class TeamPanel(BoxLayout):
+    team_index = NumericProperty(0)
     team_name = StringProperty("")
     team_color = ListProperty([0.1, 0.1, 0.1, 0.3])
     is_winner = BooleanProperty(False)
@@ -341,12 +408,31 @@ class TeamsPanel(StackLayout):
         self.team.append(self.ids["team0"])
         self.team.append(self.ids["team1"])
 
-        self.team[0].team_name = self.ms["TeamName"][0]
-        self.team[1].team_name = self.ms["TeamName"][1]
+        team_names = self.ms.get("TeamName", ["", ""])
+        team0_name = team_names[0] if len(team_names) > 0 else ""
+        team1_name = team_names[1] if len(team_names) > 1 else ""
+        self.set_team_name(0, team0_name)
+        self.set_team_name(1, team1_name)
 
-        if self.team[0].team_name == "" or self.team[1].team_name == "":
-            self.team[0].team_name = "Team0"
-            self.team[1].team_name = "Team1"
+    def set_team_name(self, team_index, team_name):
+        if team_index not in (0, 1):
+            return
+
+        normalized_name = str(team_name).strip() if team_name is not None else ""
+        if normalized_name == "":
+            normalized_name = "Team{}".format(team_index)
+
+        if 0 <= team_index < len(self.team):
+            self.team[team_index].team_name = normalized_name
+
+        if self.ms and "TeamName" in self.ms:
+            team_names = self.ms["TeamName"]
+            if not isinstance(team_names, list):
+                team_names = list(team_names)
+                self.ms["TeamName"] = team_names
+            while len(team_names) < 2:
+                team_names.append("")
+            team_names[team_index] = normalized_name
 
     def load_round(self, rss, index):
         self.rss = rss
@@ -400,6 +486,7 @@ class TeamsPanel(StackLayout):
         for i, p in enumerate(self.player_list):
             if i >= total_players:
                 break
+            p.player_index = i
             p.slot = (i + 1) % 10
             p.name = self.rss["PlayerNames"][i]
 

--- a/kdv_parser/cmd/parser/main.go
+++ b/kdv_parser/cmd/parser/main.go
@@ -32,7 +32,6 @@ func main() {
 }
 
 func printKDVVersion() {
-	fmt.Printf("[startup] kdv: %s\n", appversion.KDV)
 	fmt.Printf("[startup] kdzformat: %d\n", appversion.KDZFormat)
 }
 

--- a/kdv_parser/cmd/parser/main.go
+++ b/kdv_parser/cmd/parser/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 	"runtime/debug"
 
 	"kdv_parser/internal/config"
@@ -13,6 +14,11 @@ import (
 const demoInfocsModule = "github.com/markus-wa/demoinfocs-golang/v5"
 
 func main() {
+	if len(os.Args) == 2 && os.Args[1] == "-v" {
+		fmt.Println(appversion.KDZFormat)
+		return
+	}
+
 	printKDVVersion()
 	printDemoInfocsVersion()
 

--- a/kdv_parser/internal/pipeline/init_ps_state.go
+++ b/kdv_parser/internal/pipeline/init_ps_state.go
@@ -37,7 +37,6 @@ func newBaseParseState(cfg config.Config, meta *RoundMeta, psr demoinfocs.Parser
 	demMD5, _ := md5sum(cfg.SourcePath)
 	st.out.Header.OriginalHash = demMD5
 
-	st.out.MatchStats.KdmVersion = appversion.KDV
 	st.out.MatchStats.KdzFormatVersion = appversion.KDZFormat
 	return st
 }

--- a/kdv_parser/internal/version/version.go
+++ b/kdv_parser/internal/version/version.go
@@ -1,4 +1,3 @@
 package version
 
-const KDV = "1.0.3"
 const KDZFormat = 1

--- a/kdv_parser/pkg/kumadem/matchstats.go
+++ b/kdv_parser/pkg/kumadem/matchstats.go
@@ -7,7 +7,6 @@ import (
 )
 
 type MatchStats struct {
-	KdmVersion       string
 	KdzFormatVersion int
 	Title            string
 	HltvLink         string


### PR DESCRIPTION
## Summary
- Integrate changes from PR2
- Add inline team/player renaming with saved KDZ overrides
- Preserve name overrides when reparsing demos
- Use parser-reported KDZ format version for compatibility checks
- Stop playback at the final snapshot